### PR TITLE
Relax target scitype check for BinaryThresholdPredictor to allow `Unknown`

### DIFF
--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -128,8 +128,9 @@ end
 ####################################
 
 function clean!(model::ThresholdUnion)
-    if !(AbstractVector{Multiclass{2}} <: target_scitype(model.model) ||
-        AbstractVector{OrderedFactor{2}} <: target_scitype(model.model))
+    T = target_scitype(model.model)
+    if !(AbstractVector{Multiclass{2}} <: T ||
+        AbstractVector{OrderedFactor{2}} <: T || Unknown <: T)
         throw(ArgumentError("`model` has unsupported target_scitype "*
               "`$(target_scitype(model.model))`. "))
     end


### PR DESCRIPTION
Sometimes a composite type (eg, `Pipeline`) is not able to infer the `target_scitype`, which falls back to `Unknown`. It is consistent with MLJBase logic to simply drop the type check in that case. 

