### PR TITLE
Improve inheritance for `BinaryThresholdPredictor` from atomic model

### DIFF
--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -326,3 +326,8 @@ end
 MMI.iteration_parameter(model::ThresholdUnion) =
     MLJModels.prepend(:model, MMI.iteration_parameter(model.model))
 
+
+# ## TRAINING LOSSES SUPPORT
+
+MMI.training_losses(thresholder::ThresholdUnion, thresholder_report) =
+    MMI.training_losses(thresholder.model, thresholder_report.model_report)

--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -242,10 +242,10 @@ function _predict_threshold(yhat::UnivariateFiniteArray{S,V,R,P,N},
     return ret
 end
 
-## METADATA
+
+## TRAITS
 
 # Note: input traits are inherited from the wrapped model
-
 
 MMI.package_name(::Type{<:ThresholdUnion}) = "MLJModels"
 MMI.package_uuid(::Type{<:ThresholdUnion}) = ""
@@ -256,26 +256,73 @@ MMI.package_url(::Type{<:ThresholdUnion}) =
 for New in THRESHOLD_TYPE_EXS
     New_str = string(New)
     quote
-        MMI.is_pure_julia(::Type{<:$New{M}}) where M =
-            MMI.is_pure_julia(M)
-        MMI.supports_weights(::Type{<:$New{M}}) where M =
-            MMI.supports_weights(M)
-        MMI.supports_class_weights(::Type{<:$New{M}}) where M =
-            MMI.supports_weights(M)
-        MMI.load_path(::Type{<:$New}) =
-            "MLJModels.$($New_str)"
-        MMI.input_scitype(::Type{<:$New{M}}) where M =
-            MMI.input_scitype(M)
-        function MMI.target_scitype(::Type{<:$New{M}}) where M
-            T = MMI.target_scitype(M)
-            if T <: AbstractVector{<:OrderedFactor}
-                return AbstractVector{<:OrderedFactor{2}}
-            elseif T <: AbstractVector{<:Multiclass}
-                return AbstractVector{<:Multiclass{2}}
-            elseif T <: AbstractVector{<:Finite}
-                return AbstractVector{<:Finite{2}}
-            end
-            return T
-        end
+        MMI.load_path(::Type{<:$New{M}}) where M = "MLJModels."*$New_str
     end |> eval
 end
+
+
+for trait in [:supports_weights,
+              :supports_class_weights,
+              :is_pure_julia,
+              :input_scitype,
+              :output_scitype,
+              :supports_training_losses,
+              ]
+
+    # try to get trait at level of types ("failure" here just
+    # means falling back to `Unknown`):
+    for New in THRESHOLD_TYPE_EXS
+        quote
+            MMI.$trait(::Type{<:$New{M}}) where M = MMI.$trait(M)
+        end |> eval
+    end
+
+    # needed because traits are not always deducable from
+    # the type (eg, `target_scitype` and `Pipeline` models):
+    eval(:(MMI.$trait(model::ThresholdUnion) = MMI.$trait(model.model)))
+end
+
+
+# ## Target scitype
+
+_make_binary(::Type) = Unknown
+_make_binary(::Type{<:AbstractVector{<:OrderedFactor}}) =
+    AbstractVector{<:OrderedFactor{2}}
+_make_binary(::Type{<:AbstractVector{<:Multiclass}}) =
+    AbstractVector{<:Multiclass{2}}
+_make_binary(::Type{<:AbstractVector{<:Finite}}) =
+    AbstractVector{<:Finite{2}}
+_make_binary(::Type{<:AbstractVector{<:Union{Missing,OrderedFactor}}}) =
+    AbstractVector{<:Union{Missing,OrderedFactor{2}}}
+_make_binary(::Type{<:AbstractVector{<:Union{Missing,Multiclass}}}) =
+    AbstractVector{<:Union{Missing,Multiclass{2}}}
+_make_binary(::Type{<:AbstractVector{<:Union{Missing,Finite}}}) =
+    AbstractVector{<:Union{Missing,Finite{2}}}
+
+# at level of types:
+for New in THRESHOLD_TYPE_EXS
+    quote
+        MMI.target_scitype(::Type{<:$New{M}}) where M =
+            _make_binary(MMI.target_scitype(M))
+    end |> eval
+end
+
+# at level of instances:
+MMI.target_scitype(model::ThresholdUnion) =
+    _make_binary(MMI.target_scitype(model.model))
+
+
+# ## Iteration parameter
+
+# at level of types:
+for New in THRESHOLD_TYPE_EXS
+    quote
+        MMI.iteration_parameter(::Type{<:$New{M}}) where M =
+            MLJModels.prepend(:model, MMI.iteration_parameter(M))
+    end |> eval
+end
+
+# at level of instances:
+MMI.iteration_parameter(model::ThresholdUnion) =
+    MLJModels.prepend(:model, MMI.iteration_parameter(model.model))
+

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -50,3 +50,25 @@ function request(query, options...)
     end
     return choice
 end
+
+
+"""
+    MLJModels.prepend(::Symbol, ::Union{Symbol,Expr,Nothing})
+
+For prepending symbols in expressions like `:(y.w)` and `:(x1.x2.x3)`.
+
+julia> prepend(:x, :y)
+:(x.y)
+
+julia> prepend(:x, :(y.z))
+:(x.y.z)
+
+julia> prepend(:w, ans)
+:(w.x.y.z)
+
+If the second argument is `nothing`, then `nothing` is returned.
+
+"""
+prepend(s::Symbol, ::Nothing) = nothing
+prepend(s::Symbol, t::Symbol) = Expr(:(.), s, QuoteNode(t))
+prepend(s::Symbol, ex::Expr) = Expr(:(.), prepend(s, ex.args[1]), ex.args[2])

--- a/test/builtins/ThresholdPredictors.jl
+++ b/test/builtins/ThresholdPredictors.jl
@@ -162,6 +162,28 @@ end
         AbstractVector{<:Union{Missing,Finite{2}}}
 end
 
+struct DummyIterativeClassifier <: MMI.Probabilistic end
+
+MMI.fit(::DummyIterativeClassifier, verbosity, data...) =
+    42, nothing, (; losses = [1.0, 2.0])
+MMI.training_losses(::DummyIterativeClassifier, report) = report.losses
+
+MMI.iteration_parameter(::Type{<:DummyIterativeClassifier}) = :n
+MMI.supports_training_losses(::Type{<:DummyIterativeClassifier}) = true
+MMI.target_scitype(::Type{<:DummyIterativeClassifier}) =
+    AbstractVector{Multiclass{2}}
+
+@testset "training losses support" begin
+    X = ones(3, 2)
+    y = ScientificTypes.coerce(["Y", "Y", "N"], OrderedFactor)
+
+    thresholder = BinaryThresholdPredictor(DummyIterativeClassifier())
+    __, __, re = MMI.fit(thresholder, 0, X, y)
+
+    @test MMI.supports_training_losses(thresholder)
+    @test MMI.training_losses(thresholder, re) == [1.0, 2.0]
+end
+
 end # module
 
 true

--- a/test/builtins/ThresholdPredictors.jl
+++ b/test/builtins/ThresholdPredictors.jl
@@ -2,6 +2,7 @@ module TestThresholdPredictors
 using Test, MLJModels, CategoricalArrays
 import MLJBase
 using CategoricalDistributions
+using ScientificTypes
 
 const MMI = MLJModels.MLJModelInterface
 
@@ -57,13 +58,12 @@ y2 = categorical(yraw[2:end], ordered=true)
     @test MMI.predict(model, model_fr, X) ==
         [y[1] for i in 1:MMI.nrows(X)]
 
-    d = MLJModels.info_dict(model)
-    @test d[:supports_weights] == MMI.supports_weights(model.model)
-    @test d[:input_scitype] == MMI.input_scitype(model.model)
-    @test d[:target_scitype] == AbstractVector{<:MMI.Finite{2}}
-    @test d[:is_pure_julia] == MMI.is_pure_julia(model.model)
-    @test d[:name] == "BinaryThresholdPredictor"
-    @test d[:load_path] == "MLJModels.BinaryThresholdPredictor"
+    @test MMI.supports_weights(model) == MMI.supports_weights(model.model)
+    @test MMI.input_scitype(model) == MMI.input_scitype(model.model)
+    @test MMI.target_scitype(model) == AbstractVector{<:MMI.Finite{2}}
+    @test MMI.is_pure_julia(model) == MMI.is_pure_julia(model.model)
+    @test MMI.name(model) == "BinaryThresholdPredictor"
+    @test MMI.load_path(model) == "MLJModels.BinaryThresholdPredictor"
 end
 
 @testset "_predict_threshold" begin
@@ -147,5 +147,21 @@ MMI.input_scitype(::Type{<:DummyDetector}) = MMI.Table
     @test e.measurement[1] ≈ 0
 end
 
+@testset "_make_binary" begin
+    @test MLJModels._make_binary(AbstractVector{<:Multiclass}) ==
+        AbstractVector{<:Multiclass{2}}
+    @test MLJModels._make_binary(AbstractVector{<:Union{Missing,Multiclass}}) ==
+        AbstractVector{<:Union{Missing,Multiclass{2}}}
+    @test MLJModels._make_binary(AbstractVector{<:OrderedFactor}) ==
+        AbstractVector{<:OrderedFactor{2}}
+    @test MLJModels._make_binary(AbstractVector{<:Union{Missing,OrderedFactor}}) ==
+        AbstractVector{<:Union{Missing,OrderedFactor{2}}}
+    @test MLJModels._make_binary(AbstractVector{<:Finite}) ==
+        AbstractVector{<:Finite{2}}
+    @test MLJModels._make_binary(AbstractVector{<:Union{Missing,Finite}}) ==
+        AbstractVector{<:Union{Missing,Finite{2}}}
 end
+
+end # module
+
 true


### PR DESCRIPTION
This PR cleans up the trait declarations for `BinaryThresholdPredictor`. In particular:

- `iteration_parameter` trait inherits from atomic model: If, say, `:n` is the atomic value, then the wrapper gets the value `:(model.n)`. Previously, this returned `:unknown` always.
- `supports_training_losses` trait now inherits from atomic model. Previously returned `false` always.
- `training_losses(model, report)` accessor function now inherits from atomic model. Previously returned `nothing` always.

These improvements help `BinaryThresholdPredictor` play better with `IteratedModel`.
