### PR TITLE
Add missing value propagation to OneHotEncoder

### DIFF
--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -846,7 +846,7 @@ function MMI.fit(transformer::OneHotEncoder, verbosity::Int, X)
         end
     end
 
- 
+
     ref_name_pairs_given_feature = Dict{Symbol,Vector{Pair{<:Unsigned,Symbol}}}()
 
     allowed_scitypes = ifelse(transformer.ordered_factor, Union{Missing, Finite}, Union{Missing, Multiclass})
@@ -904,13 +904,13 @@ hot(v::AbstractVector{<:CategoricalValue}, ref) = map(v) do c
     MMI.int(c) == ref
 end
 
-function hot(col::AbstractVector{<:Union{Missing, CategoricalValue}}, ref) map(col) do c  
+function hot(col::AbstractVector{<:Union{Missing, CategoricalValue}}, ref) map(col) do c
     if ismissing(ref)
-        missing 
-    else 
-        MMI.int(c) == ref 
-    end 
-end 
+        missing
+    else
+        MMI.int(c) == ref
+    end
+end
 end
 
 function MMI.transform(transformer::OneHotEncoder, fitresult, X)
@@ -937,8 +937,8 @@ function MMI.transform(transformer::OneHotEncoder, fitresult, X)
             pairs = d[ftr]
             refs = first.(pairs)
             names = last.(pairs)
-            cols_to_add = map(refs) do ref 
-                if ismissing(ref) missing 
+            cols_to_add = map(refs) do ref
+                if ismissing(ref) missing
                 else float.(hot(col, ref))
                 end
             end

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -510,7 +510,7 @@ end
     @test collect(skipmissing(Xt.name__John)) == float.([false, true, false, true])
     @test ismissing(Xt.name__John[5])
     @test Xt.height == X.height
-    @test ismissing(Xt.favourite_number__5) == 5
+    @test ismissing(Xt.favourite_number__5[4])
     @test collect(skipmissing(Xt.favourite_number__5)) == float.([false, true, false, true])
     @test ismissing(Xt.favourite_number__5[4])
     @test Xt.age == X.age

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -58,7 +58,7 @@ _get(x) = CategoricalArrays.DataAPI.unwrap(x)
 
     # features must be specified if ignore=true
     @test_throws ArgumentError FeatureSelector(ignore=true)
-     
+
     # test logs for no features selected when using Bool-Callable function interface:
     selector = FeatureSelector(features= x-> x == (:x1))
    @test_throws(
@@ -71,7 +71,7 @@ _get(x) = CategoricalArrays.DataAPI.unwrap(x)
         ArgumentError,
         MLJBase.fit(selector, 1, X)
     )
-    
+
     # Test model Metadata
     infos = MLJModels.info_dict(selector)
     @test infos[:input_scitype]  == MLJBase.Table
@@ -446,7 +446,7 @@ end
          age        = [23, 23, 14, 23],
          gender     = categorical(['M', 'M', 'F', 'M']))
     @test_throws Exception MLJBase.transform(t, f, X)
-    
+
     # test to throw exception when category level mismatch is found
     X = (name   = categorical(["Ben", "John", "Mary", "John"], ordered=true),
          height = [1.85, 1.67, 1.5, 1.67],
@@ -468,19 +468,23 @@ end
 
     # test the work on missing values
     X = (name   = categorical(["Ben", "John", "Mary", "John", missing], ordered=true),
-         height = [1.85, 1.67, 1.5, 1.67],
+         height = [1.85, 1.67, 1.5, 1.67, 1.56],
          favourite_number = categorical([7, 5, 10, missing, 5]),
-         age    = [23, 23, 14, 23])
+         age    = [23, 23, 14, 23, 21])
 
     t  = OneHotEncoder()
     f, _, report = @test_logs((:info, r"Spawning 3"),
                          (:info, r"Spawning 3"), MLJBase.fit(t, 1, X))
-     
+
     Xt = MLJBase.transform(t, f, X)
 
-    @test typeof(Xt.name__John == float.([false, true, false, true, missing])) == Missing
+    @test length(Xt.name__John) == 5
+    @test collect(skipmissing(Xt.name__John)) == float.([false, true, false, true])
+    @test ismissing(Xt.name__John[5])
     @test Xt.height == X.height
-    @test typeof(Xt.favourite_number__10 == float.([false, false, true, false, missing])) == Missing
+    @test length(Xt.favourite_number__10) == 5
+    @test collect(skipmissing(Xt.favourite_number__10)) == float.([false, false, true, false])
+    @test ismissing(Xt.favourite_number__10[4])
     @test Xt.age == X.age
     @test MLJBase.schema(Xt).names == (:name__Ben, :name__John, :name__Mary,
                                :height, :favourite_number__5,
@@ -492,9 +496,9 @@ end
     # test the work on missing values with drop_last = true
 
     X = (name   = categorical(["Ben", "John", "Mary", "John", missing], ordered=true),
-         height = [1.85, 1.67, 1.5, 1.67],
+         height = [1.85, 1.67, 1.5, 1.67, 1.56],
          favourite_number = categorical([7, 5, 10, missing, 5]),
-         age    = [23, 23, 14, 23])
+         age    = [23, 23, 14, 23, 21])
 
     t  = OneHotEncoder(drop_last = true)
     f, _, report = @test_logs((:info, r"Spawning 2"),
@@ -502,9 +506,13 @@ end
 
     Xt = MLJBase.transform(t, f, X)
 
-    @test typeof(Xt.name__John == float.([false, true, false, true, missing])) == Missing
+    @test length(Xt.name__John) == 5
+    @test collect(skipmissing(Xt.name__John)) == float.([false, true, false, true])
+    @test ismissing(Xt.name__John[5])
     @test Xt.height == X.height
-    @test typeof(Xt.favourite_number__5 == float.([false, true, false, missing, true])) == Missing
+    @test ismissing(Xt.favourite_number__5) == 5
+    @test collect(skipmissing(Xt.favourite_number__5)) == float.([false, true, false, true])
+    @test ismissing(Xt.favourite_number__5[4])
     @test Xt.age == X.age
     @test MLJBase.schema(Xt).names == (:name__Ben, :name__John,
                             :height, :favourite_number__5,
@@ -513,9 +521,7 @@ end
 
     @test_throws Exception Xt.favourite_number__10
     @test_throws Exception Xt.name__Mary
-
     @test report.new_features == collect(MLJBase.schema(Xt).names)
-
 end
 
 


### PR DESCRIPTION
The behaviour is as follows:

```julia
julia> X = (name = categorical(["a", "b", "c", "a", "b", missing]),)
(name = Union{Missing, CategoricalArrays.CategoricalValue{String, UInt32}}["a", "b", "c", "a", "b", missing],)

julia> mach = machine(OneHotEncoder(), X)
Machine{OneHotEncoder,…} trained 0 times; caches data
  model: OneHotEncoder
  args: 
    1:  Source @492 ⏎ `Table{AbstractVector{Union{Missing, Multiclass{3}}}}`


julia> fit!(mach)
[ Info: Training Machine{OneHotEncoder,…}.
[ Info: Spawning 3 sub-features to one-hot encode feature :name.
Machine{OneHotEncoder,…} trained 1 time; caches data
  model: OneHotEncoder
  args: 
    1:  Source @492 ⏎ `Table{AbstractVector{Union{Missing, Multiclass{3}}}}`


julia> transform(mach)
(name__a = Union{Missing, Float64}[1.0, 0.0, 0.0, 1.0, 0.0, missing],
 name__b = Union{Missing, Float64}[0.0, 1.0, 0.0, 0.0, 1.0, missing],
 name__c = Union{Missing, Float64}[0.0, 0.0, 1.0, 0.0, 0.0, missing],)

julia> 
```