### PR TITLE
fix bug in data front-end issue#440

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -41,6 +41,7 @@ Tables = "0.2,1.0"
 julia = "1.3"
 
 [extras]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJDecisionTreeInterface = "c6f25543-311c-4c74-83dc-3ea6d1015661"
 MLJMultivariateStatsInterface = "1b6a4a23-ba22-4f51-9698-8599985d3728"
@@ -49,4 +50,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["MLJBase", "MLJDecisionTreeInterface", "MLJMultivariateStatsInterface", "Pkg", "StableRNGs", "Test"]
+test = ["Distributions", "MLJBase", "MLJDecisionTreeInterface", "MLJMultivariateStatsInterface", "Pkg", "StableRNGs", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -38,7 +38,7 @@ ScientificTypes = "3"
 StatisticalTraits = "3"
 StatsBase = "0.32,0.33"
 Tables = "0.2,1.0"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/MLJModels.jl
+++ b/src/MLJModels.jl
@@ -2,7 +2,7 @@ module MLJModels
 
 import MLJModelInterface
 import MLJModelInterface: Model, metadata_pkg, metadata_model, @mlj_model, info,
-    nrows, selectcols, transform, inverse_transform, fitted_params
+    nrows, selectrows, reformat, selectcols, transform, inverse_transform, fitted_params
 for T in MLJModelInterface.ABSTRACT_MODEL_SUBTYPES
     @eval(import MLJModelInterface.$T)
 end

--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -138,7 +138,7 @@ function MMI.fit(model::ThresholdUnion, verbosity::Int, args...)
         end
     end
     model_fitresult, model_cache, model_report = MMI.fit(
-        model.model, verbosity-1, map(unwrap_target, args)...
+        model.model, verbosity-1, map(unwrap, args)...
     )
     cache = (model_cache = model_cache,)
     report = (model_report = model_report,)
@@ -154,7 +154,7 @@ function MMI.update(
         verbosity-1,
         old_fitresult[1],
         old_cache[1],
-        map(unwrap_target, args)...
+        map(unwrap, args)...
     )
     cache = (model_cache = model_cache,)
     report = (model_report = model_report,)
@@ -320,35 +320,35 @@ MMI.training_losses(thresholder::ThresholdUnion, thresholder_report) =
 
 ## Data Front-end
 """
-    ReformattedTarget(y, levs, sci_type)
+    ReformattedTarget(y, levels, scitype)
 
 Intenal Use Only.
 Wrapper containing a **model specific** target, `y`, its scientific type, 
-`sci_type`(the scientific representation of the **user supplied** target), 
-and associated levels (the levels of the **user supplied** target), `levs`.
+`scitype`(the scientific representation of the **user supplied** target), 
+and associated levels (the levels of the **user supplied** target), `levels`.
 """
 struct ReformattedTarget{T, L, S<:Type}
     y::T
-    levs::L
-    sci_type::S
+    levels::L
+    scitype::S
 end
 
 function Base.:(==)(x1::ReformattedTarget, x2::ReformattedTarget)
-    return x1.y == x2.y && x1.levs == x2.levs && x1.sci_type == x2.sci_type
+    return x1.y == x2.y && x1.levels == x2.levels && x1.scitype == x2.scitype
 end
 
-unwrap_target(x) = x
-unwrap_target(x::ReformattedTarget) = getfield(x, :y)
-CategoricalArrays.levels(x::ReformattedTarget) = getfield(x, :levs) 
+unwrap(x) = x
+unwrap(x::ReformattedTarget) = getfield(x, :y)
+CategoricalArrays.levels(x::ReformattedTarget) = getfield(x, :levels) 
 
 function ScientificTypesBase.scitype(
     x::ReformattedTarget, ::ScientificTypes.DefaultConvention
 )
-    return getfield(x, :sci_type)
+    return getfield(x, :scitype)
 end
 
-# Faster acesss to sci_type for `ReformattedTarget`
-get_scitype(x::ReformattedTarget) = x.sci_type
+# Faster acesss to scitype for `ReformattedTarget`
+get_scitype(x::ReformattedTarget) = x.scitype
 
 function MMI.reformat(model::ThresholdUnion, args...)
     atom = model.model
@@ -370,7 +370,7 @@ end
 function MMI.selectrows(model::ThresholdUnion, I, reformatted_args_with_wrapped_target...)
     atom = model.model
     reformatted_args_rows = selectrows(
-        atom, I, map(unwrap_target, reformatted_args_with_wrapped_target)...
+        atom, I, map(unwrap, reformatted_args_with_wrapped_target)...
     )
 
     if length(reformatted_args_with_wrapped_target) > 1

--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -347,7 +347,7 @@ function ScientificTypesBase.scitype(
     return getfield(x, :sci_type)
 end
 
-#faster acesss to sci_type
+# Faster acesss to sci_type for `ReformattedTarget`
 get_scitype(x::ReformattedTarget) = x.sci_type
 
 function MMI.reformat(model::ThresholdUnion, args...)

--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -127,7 +127,7 @@ end
 function MMI.fit(model::ThresholdUnion, verbosity::Int, args...)
 
     if length(args) > 1 &&
-        !(scitype(args[2]) <: AbstractVector{<:Union{Missing,OrderedFactor}})
+        !(get_scitype(args[2]) <: AbstractVector{<:Union{Missing, OrderedFactor{2}}})
         L = levels(args[2])
         length(L) == 2 || throw(ERR_TARGET_NOT_BINARY)
         first_class, second_class = L
@@ -138,7 +138,7 @@ function MMI.fit(model::ThresholdUnion, verbosity::Int, args...)
         end
     end
     model_fitresult, model_cache, model_report = MMI.fit(
-        model.model, verbosity-1, args...
+        model.model, verbosity-1, map(unwrap_target, args)...
     )
     cache = (model_cache = model_cache,)
     report = (model_report = model_report,)
@@ -150,7 +150,11 @@ function MMI.update(
     model::ThresholdUnion, verbosity::Int, old_fitresult, old_cache, args...
 )
     model_fitresult, model_cache, model_report = MMI.update(
-        model.model, verbosity-1, old_fitresult[1], old_cache[1], args...
+        model.model,
+        verbosity-1,
+        old_fitresult[1],
+        old_cache[1],
+        map(unwrap_target, args)...
     )
     cache = (model_cache = model_cache,)
     report = (model_report = model_report,)
@@ -313,3 +317,79 @@ MMI.iteration_parameter(model::ThresholdUnion) =
 
 MMI.training_losses(thresholder::ThresholdUnion, thresholder_report) =
     MMI.training_losses(thresholder.model, thresholder_report.model_report)
+
+## Data Front-end
+"""
+    ReformattedTarget(y, levs, sci_type)
+
+Intenal Use Only.
+Wrapper containing a **model specific** target, `y`, its scientific type, 
+`sci_type`(the scientific representation of the **user supplied** target), 
+and associated levels (the levels of the **user supplied** target), `levs`.
+"""
+struct ReformattedTarget{T, L, S<:Type}
+    y::T
+    levs::L
+    sci_type::S
+end
+
+function Base.:(==)(x1::ReformattedTarget, x2::ReformattedTarget)
+    return x1.y == x2.y && x1.levs == x2.levs && x1.sci_type == x2.sci_type
+end
+
+unwrap_target(x) = x
+unwrap_target(x::ReformattedTarget) = getfield(x, :y)
+CategoricalArrays.levels(x::ReformattedTarget) = getfield(x, :levs) 
+
+function ScientificTypesBase.scitype(
+    x::ReformattedTarget, ::ScientificTypes.DefaultConvention
+)
+    return getfield(x, :sci_type)
+end
+
+#faster acesss to sci_type
+get_scitype(x::ReformattedTarget) = x.sci_type
+
+function MMI.reformat(model::ThresholdUnion, args...)
+    atom = model.model
+    reformatted_args = reformat(atom, args...)
+    if length(args) > 1
+        reformatted_X, reformatted_target, other_reformatted_args... = reformatted_args
+        target = args[2]
+        wrapped_reformatted_target = ReformattedTarget(
+            reformatted_target, levels(target), scitype(target)
+        )
+        reformatted_args_with_wrapped_target = (
+            reformatted_X, wrapped_reformatted_target, other_reformatted_args...
+        )
+        return reformatted_args_with_wrapped_target
+    end
+    return reformatted_args
+end
+
+function MMI.selectrows(model::ThresholdUnion, I, reformatted_args_with_wrapped_target...)
+    atom = model.model
+    reformatted_args_rows = selectrows(
+        atom, I, map(unwrap_target, reformatted_args_with_wrapped_target)...
+    )
+
+    if length(reformatted_args_with_wrapped_target) > 1
+        reformatted_X_rows, reformatted_target_rows, other_reformatted_args_rows... = 
+            reformatted_args_rows
+        reformatted_target = reformatted_args_with_wrapped_target[2]
+        wrapped_reformatted_target_rows = ReformattedTarget(
+            reformatted_target_rows, 
+            levels(reformatted_target),
+            get_scitype(reformatted_target)
+        )
+
+        reformatted_args_rows_with_wrapped_target = (
+            reformatted_X_rows, 
+            wrapped_reformatted_target_rows, 
+            other_reformatted_args_rows...
+        )
+        return reformatted_args_rows_with_wrapped_target
+    end
+
+    return reformatted_args_rows
+end

--- a/test/builtins/ThresholdPredictors.jl
+++ b/test/builtins/ThresholdPredictors.jl
@@ -254,8 +254,8 @@ MMI.input_scitype(::Type{<:NaiveClassifier}) = Table(Continuous)
         (y[I],), levels(y[I]), scitype(y[I])
     )
     @test r[2].y == s.y
-    @test r[2].levs == s.levs
-    @test r[2].sci_type == s.sci_type
+    @test r[2].levels == s.levels
+    @test r[2].scitype == s.scitype
 
     # machine end-end test
     mach = MLJBase.machine(threshold_classifier, X, y)


### PR DESCRIPTION
fixes #440 
```julia
julia> using MLJBase, MLJModels, EvoTrees

julia> threshold_classifier = BinaryThresholdPredictor(EvoTreeClassifier())
BinaryThresholdPredictor(
    model = EvoTreeClassifier(
            loss = EvoTrees.Softmax(),
            nrounds = 10,
            λ = 0.0,
            γ = 0.0,
            η = 0.1,
            max_depth = 5,
            min_weight = 1.0,
            rowsample = 1.0,
            colsample = 1.0,
            nbins = 64,
            α = 0.5,
            metric = :mlogloss,
            rng = Random.MersenneTwister(123),
            device = "cpu"),
    threshold = 0.5)

julia> X = MLJBase.table(rand(10, 10));

julia> y = categorical([2, 1, 1, 2, 1, 1, 2, 1, 1, 2], ordered=true);

julia> mach = machine(threshold_classifier, X, y) |> fit!
[ Info: Training Machine{BinaryThresholdPredictor{EvoTreeClassifier{Float64,…}},…}.
Machine{BinaryThresholdPredictor{EvoTreeClassifier{Float64,…}},…} trained 1 time; caches data
  model: BinaryThresholdPredictor{EvoTreeClassifier{Float64, EvoTrees.Softmax, Int64}}
  args:
    1:  Source @193 ⏎ `Table{AbstractVector{Continuous}}`
    2:  Source @152 ⏎ `AbstractVector{OrderedFactor{2}}`


julia> predict(mach, X)
10-element CategoricalArray{Int64,1,UInt8}:
 2
 1
 1
 2
 1
 1
 2
 1
 1
 2
```