### PR TITLE
`matching(X, y)` should print a warning if `y` is a table and `y` only has one column

### DIFF
--- a/src/model_search.jl
+++ b/src/model_search.jl
@@ -251,10 +251,10 @@ end
 
 not_missing_and_true(x) = !ismissing(x) && x
 
-const WARN_MULTITARGET = "y is a table with only one column. " *
-                         "If y is a table, we assume you want to do multi-target modeling." *
+const WARN_MULTITARGET = "'y' is a table with only one column. " *
+                         "If 'y' is a table, we assume you want to do multi-target modeling." *
                          "If you actually want to do single-target modeling, " *
-                         "you need to convert y to a Vector."
+                         "you need to convert 'y' to a Vector."
 
 function warn_if_single_column(y)
     if Tables.istable(y) && (length(Tables.columnnames(y)) == 1)

--- a/src/model_search.jl
+++ b/src/model_search.jl
@@ -251,15 +251,14 @@ end
 
 not_missing_and_true(x) = !ismissing(x) && x
 
+const WARN_MULTITARGET = "y is a table with only one column. " *
+                         "If y is a table, we assume you want to do multi-target modeling." *
+                         "If you actually want to do single-target modeling, " *
+                         "you need to convert y to a Vector."
+
 function warn_if_single_column(y)
     if Tables.istable(y) && (length(Tables.columnnames(y)) == 1)
-        msg = string(
-            "y is a table with only one column. ",
-            "If y is a table, we assume you want to do multi-target modeling.",
-            "If you actually want to do single-target modeling, ",
-            "you need to convert y to a Vector.",
-        )
-        @warn msg
+        @warn WARN_MULTITARGET
     end
     return nothing
 end

--- a/src/model_search.jl
+++ b/src/model_search.jl
@@ -251,11 +251,32 @@ end
 
 not_missing_and_true(x) = !ismissing(x) && x
 
-matching(X)       = Checker{false,missing,missing,scitype(X),missing}()
-matching(X, y)    = Checker{true,missing,missing,scitype(X),scitype(y)}()
-matching(X, y, w) = Checker{true,true,false,scitype(X),scitype(y)}()
-matching(X, y, w::AbstractDict) =
-    Checker{true,false,true,scitype(X),scitype(y)}()
+function warn_if_single_column(y)
+    if Tables.istable(y) && (length(Tables.columnnames(y)) == 1)
+        msg = string(
+            "y is a table with only one column. ",
+            "If y is a table, we assume you want to do multi-target modeling.",
+            "If you actually want to do single-target modeling, ",
+            "you need to convert y to a Vector.",
+        )
+        @warn msg
+    end
+    return nothing
+end
+
+matching(X) = Checker{false,missing,missing,scitype(X),missing}()
+function matching(X, y)
+    warn_if_single_column(y)
+    return Checker{true,missing,missing,scitype(X),scitype(y)}()
+end
+function matching(X, y, w)
+    warn_if_single_column(y)
+    return Checker{true,true,false,scitype(X),scitype(y)}()
+end
+function matching(X, y, w::AbstractDict)
+    warn_if_single_column(y)
+    return Checker{true,false,true,scitype(X),scitype(y)}()
+end
 
 (f::Checker{false,
             missing,

--- a/test/model_search.jl
+++ b/test/model_search.jl
@@ -92,6 +92,27 @@ end
     @test task.supports_class_weights
     @test task.input_scitype == scitype(X)
     @test task.target_scitype == scitype(y)
+
+    @testset "matching(X, y) where y is a table with a single column" begin
+        @testset begin
+            X = (; x1 = [1., 2., 3.])
+            y = [4., 5., 6.]
+            @test_nowarn matching(X, y)
+            @test_logs match_mode=:all matching(X, y)
+        end
+        @testset begin
+            X = (; x1 = [1., 2., 3.])
+            y = (; y1 = [4., 5., 6.])
+            @test_logs match_mode=:all (:warn, MLJModels.WARN_MULTITARGET) matching(X, y)
+        end
+        @testset begin
+            X = (; x1 = [1., 2., 3.])
+            y = (; y1 = [4., 5., 6.], y2 = [7., 8., 9.])
+            matching(X, y)
+            @test_nowarn matching(X, y)
+            @test_logs match_mode=:all matching(X, y)
+        end
+    end
 end
 
 @testset "models() and localmodels()" begin


### PR DESCRIPTION
See https://github.com/alan-turing-institute/MLJ.jl/issues/937 for motivation.