### PR TITLE
add InteractionTransformer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.15.9"
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 CategoricalDistributions = "af321ab8-2d2e-40a6-b165-3d674595d28e"
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -39,6 +40,7 @@ StatisticalTraits = "3"
 StatsBase = "0.32,0.33"
 Tables = "0.2,1.0"
 julia = "1.6"
+Combinatorics = "1.0"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/MLJModels.jl
+++ b/src/MLJModels.jl
@@ -17,6 +17,7 @@ const MMI = MLJModelInterface
 using Pkg, Pkg.TOML, OrderedCollections, Parameters
 using Tables, CategoricalArrays, StatsBase, Statistics, Dates
 using InteractiveUtils, Markdown
+using Combinatorics
 import Distributions
 import REPL # stdlib, needed for `Term`
 import PrettyPrinting
@@ -44,7 +45,7 @@ export BinaryThresholdPredictor
 export FeatureSelector, UnivariateDiscretizer,
     UnivariateStandardizer, Standardizer, UnivariateBoxCoxTransformer,
     OneHotEncoder, ContinuousEncoder, FillImputer, UnivariateFillImputer,
-    UnivariateTimeTypeToContinuous
+    UnivariateTimeTypeToContinuous, InteractionTransformer
 
 const srcdir = dirname(@__FILE__) # the directory containing this file
 const MMI = MLJModelInterface

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -1024,16 +1024,9 @@ end
 
 # # INTERACTION TRANSFORMER
 
-@with_kw_noshow mutable struct InteractionTransformer <: Static
-    order::Int                                          = 2
-    colnames::Union{Nothing, Vector{Symbol}}            = nothing
-    function InteractionTransformer(order, colnames)
-        order >= 2 || throw(ArgumentError("The order of interactions should be at least 2."))
-        if colnames !== nothing
-            length(colnames) > 1 || throw(ArgumentError("At least 2 columns are required to compute interactions."))
-        end
-        return new(order, colnames)
-    end
+@mlj_model mutable struct InteractionTransformer <: Static
+    order::Int                                          = 2::(_ > 1)
+    colnames::Union{Nothing, Vector{Symbol}}            = nothing::(_ !== nothing ? length(_) > 1 : true)
 end
 
 infinite_scitype(col) = eltype(scitype(col)) <: Infinite

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -657,25 +657,25 @@ end
 @testset "Interaction Transformer functions" begin
     # No column provided, A has scitype Continuous, B has scitype Count
     table = (A = [1., 2., 3.], B = [4, 5, 6], C = ["x₁", "x₂", "x₃"])
-    @test MLJModels.actualcolumns(nothing, table) == (:A, :B)
+    @test MLJModels.actualfeatures(nothing, table) == (:A, :B)
     # Column provided
-    @test MLJModels.actualcolumns([:A, :B], table) == (:A, :B)
+    @test MLJModels.actualfeatures([:A, :B], table) == (:A, :B)
     # Column provided, not in table
-    @test_throws ArgumentError("Column(s) D are not in the dataset.") MLJModels.actualcolumns([:A, :D], table)
+    @test_throws ArgumentError("Column(s) D are not in the dataset.") MLJModels.actualfeatures([:A, :D], table)
     # Non Infinite scitype column provided
-    @test_throws ArgumentError("Column C's scitype is not Infinite.") MLJModels.actualcolumns([:A, :C], table)
+    @test_throws ArgumentError("Column C's scitype is not Infinite.") MLJModels.actualfeatures([:A, :C], table)
 end
 
 
 @testset "Interaction Transformer" begin
-    # Check constructor sanity checks: order > 1, length(colnames) > 1
+    # Check constructor sanity checks: order > 1, length(features) > 1
     @test_logs (:warn, "Constraint `model.order > 1` failed; using default: order=2.") InteractionTransformer(order = 1)
-    @test_logs (:warn, "Constraint `if model.colnames !== nothing\n"*
-                       "    length(model.colnames) > 1\nelse\n    true\nend` failed; "*
-                       "using default: colnames=nothing.") InteractionTransformer(colnames = [:A])
+    @test_logs (:warn, "Constraint `if model.features !== nothing\n"*
+                       "    length(model.features) > 1\nelse\n    true\nend` failed; "*
+                       "using default: features=nothing.") InteractionTransformer(features = [:A])
 
     X = (A = [1, 2, 3], B = [4, 5, 6], C = [7, 8, 9])
-    # Default order=2, colnames=nothing, ie all columns
+    # Default order=2, features=nothing, ie all columns
     Xt = MLJBase.transform(InteractionTransformer(), nothing, X)
     @test Xt == (
         A = [1, 2, 3],
@@ -685,7 +685,7 @@ end
         A_C = [7, 16, 27],
         B_C = [28, 40, 54]
     )
-    # order=3, colnames=nothing, ie all columns
+    # order=3, features=nothing, ie all columns
     Xt = MLJBase.transform(InteractionTransformer(order=3), nothing, X)
     @test Xt == (
         A = [1, 2, 3],
@@ -696,17 +696,17 @@ end
         B_C = [28, 40, 54],
         A_B_C = [28, 80, 162]
     )
-    # order=2, colnames=[:A, :B], ie all columns
-    Xt =MLJBase.transform(InteractionTransformer(order=2, colnames=[:A, :B]), nothing, X)
+    # order=2, features=[:A, :B], ie all columns
+    Xt =MLJBase.transform(InteractionTransformer(order=2, features=[:A, :B]), nothing, X)
     @test Xt == (
         A = [1, 2, 3],
         B = [4, 5, 6],
         C = [7, 8, 9],
         A_B = [4, 10, 18]
     )
-    # order=3, colnames=[:A, :B, :C], some non continuous columns
+    # order=3, features=[:A, :B, :C], some non continuous columns
     X = merge(X, (D = ["x₁", "x₂", "x₃"],))
-    Xt = MLJBase.transform(InteractionTransformer(order=3, colnames=[:A, :B, :C]), nothing, X)
+    Xt = MLJBase.transform(InteractionTransformer(order=3, features=[:A, :B, :C]), nothing, X)
     @test Xt == (
         A = [1, 2, 3],
         B = [4, 5, 6],
@@ -717,7 +717,7 @@ end
         B_C = [28, 40, 54],
         A_B_C = [28, 80, 162]
     )
-    # order=2, colnames=nothing, only continuous columns are dealt with
+    # order=2, features=nothing, only continuous columns are dealt with
     Xt = MLJBase.transform(InteractionTransformer(order=2), nothing, X)
     @test Xt == (
         A = [1, 2, 3],

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -669,8 +669,10 @@ end
 
 @testset "Interaction Transformer" begin
     # Check constructor sanity checks: order > 1, length(colnames) > 1
-    @test_throws ArgumentError("The order of interactions should be at least 2.") InteractionTransformer(order = 1)
-    @test_throws ArgumentError("At least 2 columns are required to compute interactions.") InteractionTransformer(colnames = [:A])
+    @test_logs (:warn, "Constraint `model.order > 1` failed; using default: order=2.") InteractionTransformer(order = 1)
+    @test_logs (:warn, "Constraint `if model.colnames !== nothing\n"*
+                       "    length(model.colnames) > 1\nelse\n    true\nend` failed; "*
+                       "using default: colnames=nothing.") InteractionTransformer(colnames = [:A])
 
     X = (A = [1, 2, 3], B = [4, 5, 6], C = [7, 8, 9])
     # Default order=2, colnames=nothing, ie all columns

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -652,5 +652,81 @@ end
 
 end
 
+#### INTERACTION TRANSFORMER ####
+
+@testset "Interaction Transformer functions" begin
+    # No column provided, A has scitype Continuous, B has scitype Count
+    table = (A = [1., 2., 3.], B = [4, 5, 6], C = ["x₁", "x₂", "x₃"])
+    @test MLJModels.actualcolumns(nothing, table) == (:A, :B)
+    # Column provided
+    @test MLJModels.actualcolumns([:A, :B], table) == (:A, :B)
+    # Column provided, not in table
+    @test_throws ArgumentError("Column(s) D are not in the dataset.") MLJModels.actualcolumns([:A, :D], table)
+    # Non Infinite scitype column provided
+    @test_throws ArgumentError("Column C's scitype is not Infinite.") MLJModels.actualcolumns([:A, :C], table)
+end
+
+
+@testset "Interaction Transformer" begin
+    # Check constructor sanity checks: order > 1, length(colnames) > 1
+    @test_throws ArgumentError("The order of interactions should be at least 2.") InteractionTransformer(order = 1)
+    @test_throws ArgumentError("At least 2 columns are required to compute interactions.") InteractionTransformer(colnames = [:A])
+
+    X = (A = [1, 2, 3], B = [4, 5, 6], C = [7, 8, 9])
+    # Default order=2, colnames=nothing, ie all columns
+    Xt = MLJBase.transform(InteractionTransformer(), nothing, X)
+    @test Xt == (
+        A = [1, 2, 3],
+        B = [4, 5, 6],
+        C = [7, 8, 9],
+        A_B = [4, 10, 18],
+        A_C = [7, 16, 27],
+        B_C = [28, 40, 54]
+    )
+    # order=3, colnames=nothing, ie all columns
+    Xt = MLJBase.transform(InteractionTransformer(order=3), nothing, X)
+    @test Xt == (
+        A = [1, 2, 3],
+        B = [4, 5, 6],
+        C = [7, 8, 9],
+        A_B = [4, 10, 18],
+        A_C = [7, 16, 27],
+        B_C = [28, 40, 54],
+        A_B_C = [28, 80, 162]
+    )
+    # order=2, colnames=[:A, :B], ie all columns
+    Xt =MLJBase.transform(InteractionTransformer(order=2, colnames=[:A, :B]), nothing, X)
+    @test Xt == (
+        A = [1, 2, 3],
+        B = [4, 5, 6],
+        C = [7, 8, 9],
+        A_B = [4, 10, 18]
+    )
+    # order=3, colnames=[:A, :B, :C], some non continuous columns
+    X = merge(X, (D = ["x₁", "x₂", "x₃"],))
+    Xt = MLJBase.transform(InteractionTransformer(order=3, colnames=[:A, :B, :C]), nothing, X)
+    @test Xt == (
+        A = [1, 2, 3],
+        B = [4, 5, 6],
+        C = [7, 8, 9],
+        D = ["x₁", "x₂", "x₃"],
+        A_B = [4, 10, 18],
+        A_C = [7, 16, 27],
+        B_C = [28, 40, 54],
+        A_B_C = [28, 80, 162]
+    )
+    # order=2, colnames=nothing, only continuous columns are dealt with
+    Xt = MLJBase.transform(InteractionTransformer(order=2), nothing, X)
+    @test Xt == (
+        A = [1, 2, 3],
+        B = [4, 5, 6],
+        C = [7, 8, 9],
+        D = ["x₁", "x₂", "x₃"],
+        A_B = [4, 10, 18],
+        A_C = [7, 16, 27],
+        B_C = [28, 40, 54],
+    )
+end
+
 end
 true


### PR DESCRIPTION
This PR provides an `InteractionTransformer` as suggested in https://github.com/JuliaAI/MLJModels.jl/issues/476.

Currently the model has hyperparameters types:
- order::Int
- colnames::Union{Nothing, Vector{Symbol}}

The second one may not be the most appropriate and happy to get some advice on it.

Otherwise happy to get your review comments and implement any missing interface function if any.
