### PR TITLE
Catch unsupported model types in `BinaryThresholdPredictor`.

### DIFF
--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -67,6 +67,10 @@ const ERR_CLASSES_DETECTOR = ArgumentError(
 const ERR_TARGET_NOT_BINARY = ArgumentError(
     "Target `y` must have two classes in its  pool, even if only one "*
     "class is manifest. ")
+const err_unsupported_model_type(T) = ArgumentError(
+    "`BinaryThresholdPredictor` does not support atomic models with supertype `$T`. "*
+    "Supported supertypes are: `$(keys(_type_given_atom)`. "
+)
 
 """
     BinaryThresholdPredictor(model; threshold=0.5)
@@ -169,8 +173,10 @@ function BinaryThresholdPredictor(args...;
         atom = model
     end
 
-    metamodel =
-        _type_given_atom[MMI.abstract_type(atom)](atom, Float64(threshold))
+    A = MMI.abstract_type(atom)
+    T = get(_type_given_atom, A, nothing)
+    isnothing(T) && throw(err_unsupported_model_type(A))
+    metamodel = T(atom, Float64(threshold))
     message = clean!(metamodel)
     isempty(message) || @warn message
     return metamodel

--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -69,7 +69,7 @@ const ERR_TARGET_NOT_BINARY = ArgumentError(
     "class is manifest. ")
 const err_unsupported_model_type(T) = ArgumentError(
     "`BinaryThresholdPredictor` does not support atomic models with supertype `$T`. "*
-    "Supported supertypes are: `$(keys(_type_given_atom)`. "
+    "Supported supertypes are: `$(keys(_type_given_atom))`. "
 )
 
 """

--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -174,8 +174,7 @@ function BinaryThresholdPredictor(args...;
     end
 
     A = MMI.abstract_type(atom)
-    T = get(_type_given_atom, A, nothing)
-    isnothing(T) && throw(err_unsupported_model_type(A))
+    T = get(_type_given_atom, A, throw(err_unsupported_model_type(A)))
     metamodel = T(atom, Float64(threshold))
     message = clean!(metamodel)
     isempty(message) || @warn message

--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -174,7 +174,8 @@ function BinaryThresholdPredictor(args...;
     end
 
     A = MMI.abstract_type(atom)
-    T = get(_type_given_atom, A, throw(err_unsupported_model_type(A)))
+    T = get(_type_given_atom, A, nothing)
+    isnothing(T) && throw(err_unsupported_model_type(A))
     metamodel = T(atom, Float64(threshold))
     message = clean!(metamodel)
     isempty(message) || @warn message

--- a/test/builtins/ThresholdPredictors.jl
+++ b/test/builtins/ThresholdPredictors.jl
@@ -22,7 +22,11 @@ y2_ = categorical(yraw[2:end], ordered=true)
     @test_throws MLJModels.ERR_MODEL_UNSPECIFIED BinaryThresholdPredictor()
     model = BinaryThresholdPredictor(atom)
 
-   
+    @test_throws(
+        MLJModels.err_unsupported_model_type(MLJBase.Unsupervised),
+        BinaryThresholdPredictor(Standardizer()),
+    )
+
     # Check warning when `y` is not ordered:
     @test_logs((:warn, MLJModels.warn_classes(levels(y_)...)),
                 MMI.fit(model, 1, MMI.reformat(model, X_, y1_)...))
@@ -145,7 +149,7 @@ MMI.input_scitype(::Type{<:DummyDetector}) = MMI.Table
         detector, 1, MMI.reformat(detector, X_, y1_)...
     )
 
-    X, y = MMI.reformat(detector, X_, y_)  
+    X, y = MMI.reformat(detector, X_, y_)
     fr, _, _ = MMI.fit(detector, 0, X, y)
     @test MMI.predict(detector, fr, X) == fill("out", length(y_))
     fr, _, _ = MMI.fit(detector, 0, X)
@@ -219,7 +223,7 @@ MMI.reformat(::NaiveClassifier, X, target) = (MMI.matrix(X), (target,))
 MMI.reformat(::NaiveClassifier, X) = (MMI.matrix(X),)
 
 function MMI.selectrows(::NaiveClassifier, I, reformatted_X, reformatted_target)
-	return (reformatted_X[I, :], (reformatted_target[1][I],))
+        return (reformatted_X[I, :], (reformatted_target[1][I],))
 end
 
 MMI.selectrows(::NaiveClassifier, I, reformatted_X) = (reformatted_X[I, :],)
@@ -232,9 +236,9 @@ MMI.input_scitype(::Type{<:NaiveClassifier}) = Table(Continuous)
 
     naive_classifier = NaiveClassifier()
     threshold_classifier = BinaryThresholdPredictor(naive_classifier)
-    reformatted_args = MMI.reformat(threshold_classifier, X) 
+    reformatted_args = MMI.reformat(threshold_classifier, X)
     @test reformatted_args == (MMI.matrix(X),)
-    reformatted_args_ = MMI.reformat(threshold_classifier, X, y) 
+    reformatted_args_ = MMI.reformat(threshold_classifier, X, y)
     @test reformatted_args_ == (
         MMI.matrix(X),
         MLJModels.ReformattedTarget(
@@ -248,7 +252,7 @@ MMI.input_scitype(::Type{<:NaiveClassifier}) = Table(Continuous)
         reformatted_args...
     ) == (MMI.matrix(X)[I, :],)
 
-    r = MMI.selectrows(threshold_classifier, I, reformatted_args_...) 
+    r = MMI.selectrows(threshold_classifier, I, reformatted_args_...)
     @test r[1] == MMI.matrix(X)[I, :]
     s = MLJModels.ReformattedTarget(
         (y[I],), levels(y[I]), scitype(y[I])


### PR DESCRIPTION
To resolve #486.

Also adds a docstring to resolve https://github.com/alan-turing-institute/MLJ.jl/issues/973.