### PR TITLE
Add a workaround to fix CI failure for Julia 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -45,7 +45,6 @@ Tables = "0.2,1.0"
 julia = "1.6"
 
 [extras]
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJDecisionTreeInterface = "c6f25543-311c-4c74-83dc-3ea6d1015661"
 MLJMultivariateStatsInterface = "1b6a4a23-ba22-4f51-9698-8599985d3728"
@@ -54,4 +53,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Distributions", "MLJBase", "MLJDecisionTreeInterface", "MLJMultivariateStatsInterface", "Pkg", "StableRNGs", "Test"]
+test = ["MLJBase", "MLJDecisionTreeInterface", "MLJMultivariateStatsInterface", "Pkg", "StableRNGs", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,8 @@
+# The next two lines added as a workaround to
+# https://github.com/JuliaLang/Pkg.jl/issues/3628 (Julia 1.6):
+import Pkg
+Pkg.add(name="Statistics", version=VERSION)
+
 using Test, MLJModels
 
 @testset "registry" begin


### PR DESCRIPTION
The failure noted in #526 appears to be due to https://github.com/JuliaLang/Pkg.jl/issues/3628 . This PR adds a workaround to address the issue.