### PR TITLE
Fix input_scitype for InteractionTransformer

### DIFF
--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -1153,7 +1153,7 @@ metadata_model(UnivariateTimeTypeToContinuous,
     load_path    = "MLJModels.UnivariateTimeTypeToContinuous")
 
 metadata_model(InteractionTransformer,
-    input_scitype   = Table,
+    input_scitype   = Tuple{Table},
     output_scitype = Table,
     human_name = "interaction transformer",
     load_path    = "MLJModels.InteractionTransformer")


### PR DESCRIPTION
The meaning of `input_scitype` for `Static` models is not clear in the MLJ spec, a fact this is corrected [here](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/#Static-models-(models-that-do-not-generalize)). With this now clarified, the implementation for `InteractionTransformer` is not compliant and this PR fixes that.