### PR TITLE
Overload `save` and `restore` to address serialization issue for `BinaryThresholdPredictor`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModels"
 uuid = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.16.15"
+version = "0.16.16"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -305,6 +305,20 @@ function _predict_threshold(yhat::UnivariateFiniteArray{S,V,R,P,N},
 end
 
 
+## SERIALIZATION
+
+# function MMI.save(model::ThresholdUnion, fitresult)
+#     atomic_fitresult, threshold = fitresult
+#     atom = model.model
+#     return MMI.save(atom, atomic_fitresult), threshold
+# end
+# function MMI.restore(model::ThresholdUnion, serializable_fitresult)
+#     atomic_serializable_fitresult, threshold = serializable_fitresult
+#     atom = model.model
+#     return MMI.restore(atom, atomic_serializable_fitresult), threshold
+# end
+
+
 ## TRAITS
 
 # Note: input traits are inherited from the wrapped model

--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -307,16 +307,16 @@ end
 
 ## SERIALIZATION
 
-# function MMI.save(model::ThresholdUnion, fitresult)
-#     atomic_fitresult, threshold = fitresult
-#     atom = model.model
-#     return MMI.save(atom, atomic_fitresult), threshold
-# end
-# function MMI.restore(model::ThresholdUnion, serializable_fitresult)
-#     atomic_serializable_fitresult, threshold = serializable_fitresult
-#     atom = model.model
-#     return MMI.restore(atom, atomic_serializable_fitresult), threshold
-# end
+function MMI.save(model::ThresholdUnion, fitresult)
+    atomic_fitresult, threshold = fitresult
+    atom = model.model
+    return MMI.save(atom, atomic_fitresult), threshold
+end
+function MMI.restore(model::ThresholdUnion, serializable_fitresult)
+    atomic_serializable_fitresult, threshold = serializable_fitresult
+    atom = model.model
+    return MMI.restore(atom, atomic_serializable_fitresult), threshold
+end
 
 
 ## TRAITS

--- a/test/builtins/ThresholdPredictors.jl
+++ b/test/builtins/ThresholdPredictors.jl
@@ -320,7 +320,7 @@ end
     seekstart(io)
     mach2 = MLJBase.machine(io)
     close(io)
-    @test_broken MLJBase.predict(mach2, (; x = rand(2))) ==  yhat
+    @test MLJBase.predict(mach2, (; x = rand(2))) ==  yhat
 end
 
 end # module

--- a/test/builtins/ThresholdPredictors.jl
+++ b/test/builtins/ThresholdPredictors.jl
@@ -268,6 +268,61 @@ MMI.input_scitype(::Type{<:NaiveClassifier}) = Table(Continuous)
         mode(Distributions.fit(MLJBase.UnivariateFinite, y[I])), MLJBase.nrows(X)
     )
 end
+
+
+# define a probabilistic classifier with non-persistent `fitresult`, but which addresses
+# this by overloading `save`/`restore`:
+thing = []
+struct EphemeralClassifier <: MLJBase.Probabilistic end
+function MLJBase.fit(::EphemeralClassifier, verbosity, X, y)
+    # if I serialize/deserialized `thing` then `view` below changes:
+    view = objectid(thing)
+    p = Distributions.fit(UnivariateFinite, y)
+    fitresult = (thing, view, p)
+    return fitresult, nothing, NamedTuple()
+end
+function MLJBase.predict(::EphemeralClassifier, fitresult, X)
+    thing, view, p = fitresult
+    return view == objectid(thing) ? fill(p, MLJBase.nrows(X)) :
+        throw(ErrorException("dead fitresult"))
+end
+MLJBase.target_scitype(::Type{<:EphemeralClassifier}) = AbstractVector{OrderedFactor{2}}
+function MLJBase.save(::EphemeralClassifier, fitresult)
+    thing, _, p = fitresult
+    return (thing, p)
+end
+function MLJBase.restore(::EphemeralClassifier, serialized_fitresult)
+    thing, p = serialized_fitresult
+    view = objectid(thing)
+    return (thing, view, p)
+end
+
+# X, y = (; x = rand(8)), categorical(collect("OXXXXOOX"), ordered=true)
+# mach = machine(EphemeralClassifier(), X, y) |> fit!
+# io = IOBuffer()
+# MLJBase.save(io, mach)
+# seekstart(io)
+# mach2 = machine(io)
+# predict(mach2, X)
+
+@testset "serialization for atomic models with non-persistent fitresults" begin
+    # https://github.com/alan-turing-institute/MLJ.jl/issues/1099
+    X, y = (; x = rand(8)), categorical(collect("OXXXXOOX"), ordered=true)
+    deterministic_classifier = BinaryThresholdPredictor(
+        EphemeralClassifier(),
+        threshold=0.5,
+    )
+    mach = MLJBase.machine(deterministic_classifier, X, y)
+    MLJBase.fit!(mach, verbosity=0)
+    yhat = MLJBase.predict(mach, MLJBase.selectrows(X, 1:2))
+    io = IOBuffer()
+    MLJBase.save(io, mach)
+    seekstart(io)
+    mach2 = MLJBase.machine(io)
+    close(io)
+    @test_broken MLJBase.predict(mach2, (; x = rand(2))) ==  yhat
+end
+
 end # module
 
 true

--- a/test/builtins/ThresholdPredictors.jl
+++ b/test/builtins/ThresholdPredictors.jl
@@ -275,15 +275,15 @@ end
 thing = []
 struct EphemeralClassifier <: MLJBase.Probabilistic end
 function MLJBase.fit(::EphemeralClassifier, verbosity, X, y)
-    # if I serialize/deserialized `thing` then `view` below changes:
-    view = objectid(thing)
+    # if I serialize/deserialized `thing` then `id` below changes:
+    id = objectid(thing)
     p = Distributions.fit(UnivariateFinite, y)
-    fitresult = (thing, view, p)
+    fitresult = (thing, id, p)
     return fitresult, nothing, NamedTuple()
 end
 function MLJBase.predict(::EphemeralClassifier, fitresult, X)
-    thing, view, p = fitresult
-    return view == objectid(thing) ? fill(p, MLJBase.nrows(X)) :
+    thing, id, p = fitresult
+    return id == objectid(thing) ? fill(p, MLJBase.nrows(X)) :
         throw(ErrorException("dead fitresult"))
 end
 MLJBase.target_scitype(::Type{<:EphemeralClassifier}) = AbstractVector{OrderedFactor{2}}
@@ -293,8 +293,8 @@ function MLJBase.save(::EphemeralClassifier, fitresult)
 end
 function MLJBase.restore(::EphemeralClassifier, serialized_fitresult)
     thing, p = serialized_fitresult
-    view = objectid(thing)
-    return (thing, view, p)
+    id = objectid(thing)
+    return (thing, id, p)
 end
 
 # X, y = (; x = rand(8)), categorical(collect("OXXXXOOX"), ordered=true)


### PR DESCRIPTION
This PR addresses part of https://github.com/alan-turing-institute/MLJ.jl/issues/1099