### PR TITLE
standardize AbstractFloats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           file: lcov.info

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -503,9 +503,10 @@ mutable struct UnivariateStandardizer <: Unsupervised end
 
 function MMI.fit(transformer::UnivariateStandardizer, verbosity::Int,
              v::AbstractVector{T}) where T<:Real
-    std(v) > eps(Float64) ||
+    stdv = std(v)
+    stdv > eps(typeof(stdv)) ||
         @warn "Extremely small standard deviation encountered in standardization."
-    fitresult = (mean(v), std(v))
+    fitresult = (mean(v), stdv)
     cache = nothing
     report = NamedTuple()
     return fitresult, cache, report

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -581,7 +581,7 @@ function MMI.fit(transformer::Standardizer, verbosity::Int, X)
     is_invertible = !transformer.count && !transformer.ordered_factor
 
     # initialize fitresult:
-    fitresult_given_feature = LittleDict{Symbol,Tuple{Float64,Float64}}()
+    fitresult_given_feature = LittleDict{Symbol,Tuple{AbstractFloat,AbstractFloat}}()
 
     # special univariate case:
     if is_univariate
@@ -631,7 +631,6 @@ function MMI.fit(transformer::Standardizer, verbosity::Int, X)
             )
         end
     end
-    fitresult_given_feature = Dict{Symbol,Tuple{Float64,Float64}}()
 
     isempty(cols_to_fit) && verbosity > -1 &&
         @warn "No features to standarize."


### PR DESCRIPTION
Changes the float type of the fitresult of `Standardizer` to `AbstractFloat`. This means standardizers will no longer force floats to `Float64`.

I also removed the second definition of `fitresult_given_feature` - I think this must have been an oversight.